### PR TITLE
[#61] [Bug] Fix wrong login response type

### DIFF
--- a/lib/api/api_service.dart
+++ b/lib/api/api_service.dart
@@ -2,7 +2,6 @@ import 'package:dio/dio.dart';
 import 'package:survey_flutter/model/request/login_request.dart';
 import 'package:survey_flutter/model/request/auth_request.dart';
 import 'package:survey_flutter/model/response/login_data_response.dart';
-import 'package:survey_flutter/model/response/login_response.dart';
 import 'package:survey_flutter/model/response/user_response.dart';
 import 'package:retrofit/retrofit.dart';
 
@@ -17,7 +16,7 @@ abstract class ApiService {
   Future<List<UserResponse>> getUsers();
 
   @POST('api/v1/oauth/token')
-  Future<LoginResponse> logIn(@Body() LoginRequest loginRequest);
+  Future<LoginDataResponse> logIn(@Body() LoginRequest loginRequest);
 
   @POST('api/v1/oauth/token')
   Future<LoginDataResponse> refreshToken(@Body() AuthRequest tokenRequest);

--- a/lib/api/repository/login_repository.dart
+++ b/lib/api/repository/login_repository.dart
@@ -6,7 +6,7 @@ import 'package:survey_flutter/api/storage/shared_preference.dart';
 import 'package:survey_flutter/di/provider/dio_provider.dart';
 import 'package:survey_flutter/model/request/auth_request.dart';
 import 'package:survey_flutter/model/request/login_request.dart';
-import 'package:survey_flutter/model/response/login_response.dart';
+import 'package:survey_flutter/model/response/login_data_response.dart';
 
 final loginRepositoryProvider = Provider<LoginRepository>((ref) {
   return LoginRepositoryImpl(
@@ -16,7 +16,7 @@ final loginRepositoryProvider = Provider<LoginRepository>((ref) {
 });
 
 abstract class LoginRepository {
-  Future<LoginResponse> login(
+  Future<LoginDataResponse> login(
       {required String email, required String password});
 
   Future<void> refreshToken();
@@ -34,16 +34,17 @@ class LoginRepositoryImpl extends LoginRepository {
   final String _grantType = 'password';
 
   @override
-  Future<LoginResponse> login(
+  Future<LoginDataResponse> login(
       {required String email, required String password}) async {
     try {
-      return await _apiService.logIn(LoginRequest(
+      final result = await _apiService.logIn(LoginRequest(
         grantType: _grantType,
         email: email,
         password: password,
         clientId: FlutterConfigPlus.get('CLIENT_ID'),
         clientSecret: FlutterConfigPlus.get('CLIENT_SECRET'),
       ));
+      return result;
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);
     }

--- a/lib/model/response/login_response.dart
+++ b/lib/model/response/login_response.dart
@@ -7,7 +7,7 @@ part 'login_response.g.dart';
 @JsonSerializable()
 class LoginResponse {
   @JsonKey(name: 'id')
-  final int? id;
+  final String? id;
   @JsonKey(name: 'type')
   final String? type;
   @JsonKey(name: 'attributes')

--- a/lib/usecases/login_use_case.dart
+++ b/lib/usecases/login_use_case.dart
@@ -1,20 +1,20 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:survey_flutter/api/repository/login_repository.dart';
 import 'package:survey_flutter/model/login_parameters.dart';
-import 'package:survey_flutter/model/response/login_response.dart';
+import 'package:survey_flutter/model/response/login_data_response.dart';
 import 'package:survey_flutter/usecases/base/base_use_case.dart';
 
 final loginUseCaseProvider = Provider<LoginUseCase>((ref) {
   return LoginUseCase(ref.watch(loginRepositoryProvider));
 });
 
-class LoginUseCase extends UseCase<LoginResponse, LoginParameters> {
+class LoginUseCase extends UseCase<LoginDataResponse, LoginParameters> {
   final LoginRepository _loginRepository;
 
   LoginUseCase(this._loginRepository);
 
   @override
-  Future<Result<LoginResponse>> call(LoginParameters params) async {
+  Future<Result<LoginDataResponse>> call(LoginParameters params) async {
     try {
       final result = await _loginRepository.login(
         email: params.email,

--- a/test/api/repository/login_repository_test.dart
+++ b/test/api/repository/login_repository_test.dart
@@ -29,12 +29,12 @@ void main() {
       'When login with correct email and password, it emits corresponding response',
       () async {
         when(mockApiService.logIn(any))
-            .thenAnswer((_) async => MockUtil.loginResponse);
+            .thenAnswer((_) async => MockUtil.loginDataResponse);
 
         final result = await repository.login(
             email: MockUtil.loginRequest.email,
             password: MockUtil.loginRequest.password);
-        expect(result.id, MockUtil.loginResponse.id);
+        expect(result.loginResponse?.id, MockUtil.loginResponse.id);
       },
     );
 

--- a/test/mocks/mock_util.dart
+++ b/test/mocks/mock_util.dart
@@ -21,5 +21,5 @@ class MockUtil {
   static LoginDataResponse loginDataResponse = LoginDataResponse(loginResponse);
 
   static LoginResponse loginResponse = LoginResponse(
-      id: 1, type: 'token', loginAttributeResponse: loginAttributeResponse);
+      id: '1', type: 'token', loginAttributeResponse: loginAttributeResponse);
 }

--- a/test/usecases/login_use_case_test.dart
+++ b/test/usecases/login_use_case_test.dart
@@ -20,7 +20,7 @@ void main() {
         when(mockLoginRepository.login(
           email: anyNamed('email'),
           password: anyNamed('password'),
-        )).thenAnswer((_) async => MockUtil.loginResponse);
+        )).thenAnswer((_) async => MockUtil.loginDataResponse);
 
         final result = await loginUseCase.call(const LoginParameters(
             email: 'test@gmail.com', password: 'password'));


### PR DESCRIPTION
- Closes #61 

## What happened 👀

Login response type is wrong. Need to return `LoginResponse` inside `data`.

## Insight 📝

- Change return type of login in to `LoginDataResponse`
- Change type of `id` from `int` to `String`

## Proof Of Work 📹

Called login in and extracted the data from the result 🙇 
<img width="1401" alt="Screenshot 2023-05-03 at 12 34 12 PM" src="https://user-images.githubusercontent.com/32578035/235843035-5dba1b7d-4d80-4d9d-b5a4-5199961bd81b.png">

