### PR TITLE
[#72] [Chore] Update interceptor to refresh the token when token is expired 

### DIFF
--- a/lib/api/repository/home_repository.dart
+++ b/lib/api/repository/home_repository.dart
@@ -4,11 +4,16 @@ import 'package:survey_flutter/api/exception/network_exceptions.dart';
 import 'package:survey_flutter/api/storage/shared_preference.dart';
 import 'package:survey_flutter/di/provider/dio_provider.dart';
 import 'package:survey_flutter/model/response/survey_data_response.dart';
+import 'package:survey_flutter/usecases/refresh_token_use_case.dart';
 
 final surveyRepositoryProvider = Provider<SurveyRepository>((ref) {
   final sharedPreference = ref.watch(sharedPreferenceProvider);
+  final refreshTokenUseCase = ref.watch(refreshTokenUseCaseProvider);
   return SurveyRepositoryImpl(
-    ApiService(DioProvider().getDioAuthorized(sharedPreference)),
+    ApiService(DioProvider().getDioAuthorized(
+      sharedPreference: sharedPreference,
+      refreshTokenUseCase: refreshTokenUseCase,
+    )),
   );
 });
 

--- a/lib/di/interceptor/app_interceptor.dart
+++ b/lib/di/interceptor/app_interceptor.dart
@@ -27,7 +27,7 @@ class AppInterceptor extends Interceptor {
       final accessToken = await _sharedPreference?.getAccessToken();
       final tokenType = await _sharedPreference?.getTokenType();
       options.headers.putIfAbsent(_headerAuthorization,
-          () => "${tokenType ?? ''} ${accessToken  ?? ''}");
+          () => "${tokenType ?? ''} ${accessToken ?? ''}");
     }
     return super.onRequest(options, handler);
   }

--- a/lib/di/provider/dio_provider.dart
+++ b/lib/di/provider/dio_provider.dart
@@ -30,8 +30,8 @@ class DioProvider {
 
   Dio _createDio({bool requireAuthenticate = false}) {
     final dio = Dio();
-    final appInterceptor =
-        AppInterceptor(requireAuthenticate, dio, _sharedPreference, _refreshTokenUseCase);
+    final appInterceptor = AppInterceptor(
+        requireAuthenticate, dio, _sharedPreference, _refreshTokenUseCase);
     final interceptors = <Interceptor>[];
     interceptors.add(appInterceptor);
     if (!kReleaseMode) {

--- a/lib/di/provider/dio_provider.dart
+++ b/lib/di/provider/dio_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:survey_flutter/api/storage/shared_preference.dart';
 import 'package:survey_flutter/di/interceptor/app_interceptor.dart';
 import 'package:survey_flutter/env.dart';
+import 'package:survey_flutter/usecases/refresh_token_use_case.dart';
 
 const String headerContentType = 'Content-Type';
 const String defaultContentType = 'application/json; charset=utf-8';
@@ -10,9 +11,14 @@ const String defaultContentType = 'application/json; charset=utf-8';
 class DioProvider {
   Dio? _dio;
   SharedPreference? _sharedPreference;
+  RefreshTokenUseCase? _refreshTokenUseCase;
 
-  Dio getDioAuthorized(SharedPreference sharedPreference) {
+  Dio getDioAuthorized({
+    required SharedPreference sharedPreference,
+    required RefreshTokenUseCase refreshTokenUseCase,
+  }) {
     _sharedPreference = sharedPreference;
+    _refreshTokenUseCase = refreshTokenUseCase;
     _dio ??= _createDio(requireAuthenticate: true);
     return _dio!;
   }
@@ -25,7 +31,7 @@ class DioProvider {
   Dio _createDio({bool requireAuthenticate = false}) {
     final dio = Dio();
     final appInterceptor =
-        AppInterceptor(requireAuthenticate, dio, _sharedPreference);
+        AppInterceptor(requireAuthenticate, dio, _sharedPreference, _refreshTokenUseCase);
     final interceptors = <Interceptor>[];
     interceptors.add(appInterceptor);
     if (!kReleaseMode) {


### PR DESCRIPTION
- Closes #72 

## What happened 👀

Currently, the backend task is already completed for refreshing the token. We need to modify `app_intercpetor` to handle Http `401` and `403` errors.

## Insight 📝

- In order to make POW for this, I passed a wrong `access token` intentionally when getting the survey list

## Proof Of Work 📹

https://github.com/nimblehq/flutter-ic-kaung-thieu/assets/32578035/211493fe-de4a-4935-b3e3-55524b72c31c


