### PR TITLE
[#96] [Bug] Fix: Survey detail title not left align

### DIFF
--- a/lib/screens/detail/start_survey_content.dart
+++ b/lib/screens/detail/start_survey_content.dart
@@ -29,18 +29,24 @@ class StartSurveyContentState extends State<StartSurveyContent> {
       return Column(
         children: [
           _buildToolbar(true),
-          Padding(
-            padding: const EdgeInsets.only(top: 30.5, left: 20, right: 20),
-            child: Text(
-              widget.title,
-              style: _textTheme.titleLarge,
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Padding(
+              padding: const EdgeInsets.only(top: 30.5, left: 30, right: 20),
+              child: Text(
+                widget.title,
+                style: _textTheme.titleLarge,
+              ),
             ),
           ),
-          Padding(
-            padding: const EdgeInsets.only(top: 16, left: 20, right: 20),
-            child: Text(
-              widget.description,
-              style: _textTheme.bodyMedium,
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Padding(
+              padding: const EdgeInsets.only(top: 16, left: 34, right: 20),
+              child: Text(
+                widget.description,
+                style: _textTheme.bodyMedium,
+              ),
             ),
           ),
           const Expanded(child: SizedBox.shrink()),


### PR DESCRIPTION
- Closes #96 

## What happened 👀

The survey detail title and description are not left-aligned if the title text is short.


## Insight 📝

- Wrap both title and description into `Align` widget to be left-aligned

## Proof Of Work 📹

<img src="https://github.com/nimblehq/flutter-ic-kaung-thieu/assets/32578035/533532a4-f816-4bd4-b16a-c26f8d61b225" width=200 />
