### PR TITLE
[#33] [Chore] Add UI integration testing - (1/3) Login test

### DIFF
--- a/integration_test/login_screen_test.dart
+++ b/integration_test/login_screen_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey_flutter/screens/login/login_form.dart';
+import 'package:survey_flutter/usecases/base/base_use_case.dart';
+
+import '../test/mocks/mock_util.dart';
+import 'utils/test_util.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('LoginScreenTest', (WidgetTester tester) async {
+    when(TestUtil.mockLoginUseCase.call(any))
+        .thenAnswer((_) async => Success(MockUtil.loginDataResponse));
+    await tester.pumpWidget(TestUtil.pumpWidgetWithRealApp('/'));
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+
+    // Test invalid password
+    await tester.enterText(find.byKey(const Key(emailTextFormKey)), 'abc');
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(find.text('Please enter the valid email format.'), findsOneWidget);
+    await tester.pump(const Duration(seconds: 2));
+
+    // Test invalid password
+    await tester.enterText(find.byKey(const Key(passwordTextFormKey)), '123');
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(find.text('Password must be at least 8 characters long.'),
+        findsOneWidget);
+    await tester.pump(const Duration(seconds: 2));
+
+    await tester.enterText(find.byKey(const Key(emailTextFormKey)), '');
+    await tester.enterText(find.byKey(const Key(passwordTextFormKey)), '');
+    await tester.pumpAndSettle();
+
+    // Test valid email and password
+    await tester.enterText(find.byKey(const Key(emailTextFormKey)), 'abc@');
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(find.text('Please enter the valid email format.'), findsNothing);
+    await tester.enterText(
+        find.byKey(const Key(passwordTextFormKey)), '12345678');
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(find.text('Password must be at least 8 characters long.'),
+        findsNothing);
+    await tester.pump(const Duration(seconds: 2));
+
+    // Test navigation to detail
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+    await tester.pumpAndSettle();
+  });
+}

--- a/integration_test/login_screen_test.dart
+++ b/integration_test/login_screen_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:survey_flutter/model/response/survey_data_response.dart';
+import 'package:survey_flutter/model/response/survey_response.dart';
 import 'package:survey_flutter/screens/login/login_form.dart';
 import 'package:survey_flutter/usecases/base/base_use_case.dart';
 
@@ -14,6 +16,25 @@ void main() {
   testWidgets('LoginScreenTest', (WidgetTester tester) async {
     when(TestUtil.mockLoginUseCase.call(any))
         .thenAnswer((_) async => Success(MockUtil.loginDataResponse));
+    when(TestUtil.mockGetSurveysUseCase.call(any)).thenAnswer(
+      (_) async => Success(
+        SurveyDataResponse(
+          [
+            SurveyResponse(
+              id: '1',
+              title: 'Scarlett Bangkok',
+              coverImageUrl: mockCoverImageUrl,
+            ),
+            SurveyResponse(
+              id: '2',
+              title: 'ibis Bangkok Riverside',
+              coverImageUrl: mockCoverImageUrl,
+            ),
+          ],
+          MockUtil.metaResponse,
+        ),
+      ),
+    );
     await tester.pumpWidget(TestUtil.pumpWidgetWithRealApp('/'));
     await tester.pump(const Duration(seconds: 2));
     await tester.pump(const Duration(seconds: 1));

--- a/integration_test/utils/test_util.dart
+++ b/integration_test/utils/test_util.dart
@@ -1,25 +1,42 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_config_plus/flutter_config_plus.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:survey_flutter/api/storage/hive_storage.dart';
 import 'package:survey_flutter/main.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:survey_flutter/usecases/login_use_case.dart';
+
+import '../../test/mocks/generate_mocks.mocks.dart';
 
 class TestUtil {
+  static MockLoginUseCase mockLoginUseCase = MockLoginUseCase();
+
   /// This is useful when we test the whole app with the real configs(styling,
   /// localization, routes, etc)
   static Widget pumpWidgetWithRealApp(String initialRoute) {
     _initDependencies();
-    return MyApp();
+    return ProviderScope(
+      overrides: [
+        loginUseCaseProvider.overrideWithValue(mockLoginUseCase),
+      ],
+      child: MyApp(),
+    );
   }
 
   /// We normally use this function to test a specific [widget] without
   /// considering much about theming.
   static Widget pumpWidgetWithShellApp(Widget widget) {
     _initDependencies();
-    return MaterialApp(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: widget,
+    return ProviderScope(
+      overrides: [
+        loginUseCaseProvider.overrideWithValue(mockLoginUseCase),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: widget,
+      ),
     );
   }
 
@@ -30,7 +47,12 @@ class TestUtil {
         version: '',
         buildNumber: '',
         buildSignature: '');
-    FlutterConfigPlus.loadValueForTesting(
-        {'SECRET': 'This is only for testing'});
+    FlutterConfigPlus.loadValueForTesting({
+      'SECRET': 'This is only for testing',
+      'CLIENT_ID': 'CLIENT_ID',
+      'CLIENT_SECRET': 'CLIENT_SECRET',
+      'REST_API_ENDPOINT': 'REST_API_ENDPOINT',
+    });
+    setupHive();
   }
 }

--- a/integration_test/utils/test_util.dart
+++ b/integration_test/utils/test_util.dart
@@ -5,12 +5,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:survey_flutter/api/storage/hive_storage.dart';
 import 'package:survey_flutter/main.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:survey_flutter/usecases/get_surveys_use_case.dart';
 import 'package:survey_flutter/usecases/login_use_case.dart';
 
 import '../../test/mocks/generate_mocks.mocks.dart';
 
 class TestUtil {
   static MockLoginUseCase mockLoginUseCase = MockLoginUseCase();
+  static MockGetSurveysUseCase mockGetSurveysUseCase = MockGetSurveysUseCase();
 
   /// This is useful when we test the whole app with the real configs(styling,
   /// localization, routes, etc)
@@ -19,6 +21,7 @@ class TestUtil {
     return ProviderScope(
       overrides: [
         loginUseCaseProvider.overrideWithValue(mockLoginUseCase),
+        getSurveysUseCaseProvider.overrideWithValue(mockGetSurveysUseCase),
       ],
       child: MyApp(),
     );

--- a/lib/screens/login/login_form.dart
+++ b/lib/screens/login/login_form.dart
@@ -9,6 +9,9 @@ import 'package:survey_flutter/screens/widgets/form_field_decoration.dart';
 import 'package:survey_flutter/theme/constant.dart';
 import 'package:survey_flutter/utils/keyboard_manager.dart';
 
+const emailTextFormKey = 'emailTextFormKey';
+const passwordTextFormKey = 'passwordTextFormKey';
+
 class LoginForm extends ConsumerStatefulWidget {
   const LoginForm({Key? key}) : super(key: key);
 
@@ -25,6 +28,7 @@ class _LoginFormState extends ConsumerState<LoginForm> {
   TextTheme get _textTheme => Theme.of(context).textTheme;
 
   TextFormField get _emailTextField => TextFormField(
+        key: const Key(emailTextFormKey),
         keyboardType: TextInputType.emailAddress,
         autocorrect: false,
         decoration: FormFieldDecoration(
@@ -41,6 +45,7 @@ class _LoginFormState extends ConsumerState<LoginForm> {
       );
 
   TextFormField get _passwordTextField => TextFormField(
+        key: const Key(passwordTextFormKey),
         autocorrect: false,
         obscureText: true,
         decoration: FormFieldDecoration(

--- a/test/mocks/mock_util.dart
+++ b/test/mocks/mock_util.dart
@@ -9,6 +9,9 @@ import 'package:survey_flutter/model/response/meta_response.dart';
 import 'package:survey_flutter/model/response/survey_data_response.dart';
 import 'package:survey_flutter/model/response/survey_response.dart';
 
+const mockCoverImageUrl =
+    'https://dhdbhh0jsld0o.cloudfront.net/m/6ea42840403875928db3_';
+
 class MockUtil {
   static LoginRequest loginRequest = LoginRequest(
       grantType: 'password',


### PR DESCRIPTION
- Closes #33 

## What happened 👀

Add UI integration testing to make sure the app's flow works as expected.

## Insight 📝

- Test cases for widget only
- A test case for real device is also added but the tester needs to add secrets themselves in `TestUtil` class

## Proof Of Work 📹



https://github.com/nimblehq/flutter-ic-kaung-thieu/assets/32578035/34b70d4c-e0e0-4ef6-81ff-8e86fd7feb0a



