### PR TITLE
[#101] [Bug] Fix: Intro and outro title overflowing if when text is long and widget error

### DIFF
--- a/lib/screens/detail/survey_detail_screen.dart
+++ b/lib/screens/detail/survey_detail_screen.dart
@@ -10,6 +10,7 @@ import 'package:survey_flutter/screens/detail/multiple_choice_answers.dart';
 import 'package:survey_flutter/screens/detail/picker_answers.dart';
 import 'package:survey_flutter/screens/detail/success_submit_content.dart';
 import 'package:survey_flutter/screens/detail/nps_answer.dart';
+import 'package:survey_flutter/screens/detail/survey_intro_outro_content.dart';
 import 'package:survey_flutter/screens/detail/survey_question_content.dart';
 import 'package:survey_flutter/screens/detail/start_survey_content.dart';
 import 'package:survey_flutter/model/survey_question_model.dart';
@@ -130,22 +131,31 @@ class SurveyDetailScreenState extends ConsumerState<SurveyDetailScreen> {
                   ),
                   for (SurveyQuestionModel question
                       in surveyDetail.questions) ...[
-                    SurveyQuestionContent(
-                      title: question.text,
-                      page: _selectedPage,
-                      totalPage: surveyDetail.questions.length,
-                      onPressNext: () {
-                        FocusManager.instance.primaryFocus?.unfocus();
-                        if (_selectedPage == surveyDetail.questions.length) {
-                          widgetRef
-                              .read(surveyDetailViewModelProvider.notifier)
-                              .submitSurvey(widget.surveyId);
-                        } else {
-                          goToNextPage();
-                        }
-                      },
-                      child: _getQuestionContentChild(question),
-                    ),
+                    (question.displayType == DisplayType.intro ||
+                            question.displayType == DisplayType.outro)
+                        ? SurveyIntroOutroContent(
+                            title: question.text,
+                            page: _selectedPage,
+                            totalPage: surveyDetail.questions.length,
+                            onPressNext: goToNextPage)
+                        : SurveyQuestionContent(
+                            title: question.text,
+                            page: _selectedPage,
+                            totalPage: surveyDetail.questions.length,
+                            onPressNext: () {
+                              FocusManager.instance.primaryFocus?.unfocus();
+                              if (_selectedPage ==
+                                  surveyDetail.questions.length) {
+                                widgetRef
+                                    .read(
+                                        surveyDetailViewModelProvider.notifier)
+                                    .submitSurvey(widget.surveyId);
+                              } else {
+                                goToNextPage();
+                              }
+                            },
+                            child: _getQuestionContentChild(question),
+                          ),
                   ]
                 ],
               ),

--- a/lib/screens/detail/survey_detail_screen.dart
+++ b/lib/screens/detail/survey_detail_screen.dart
@@ -93,6 +93,17 @@ class SurveyDetailScreenState extends ConsumerState<SurveyDetailScreen> {
         var isSubmitSurveySuccess =
             widgetRef.watch(_isSubmitSuccessStreamProvider).value;
 
+        void onPressNext() {
+          FocusManager.instance.primaryFocus?.unfocus();
+          if (_selectedPage == surveyDetail?.questions.length) {
+            widgetRef
+                .read(surveyDetailViewModelProvider.notifier)
+                .submitSurvey(widget.surveyId);
+          } else {
+            goToNextPage();
+          }
+        }
+
         if (surveyDetail == null) {
           return Container(
             decoration: const BoxDecoration(color: Colors.black),
@@ -137,23 +148,12 @@ class SurveyDetailScreenState extends ConsumerState<SurveyDetailScreen> {
                             title: question.text,
                             page: _selectedPage,
                             totalPage: surveyDetail.questions.length,
-                            onPressNext: goToNextPage)
+                            onPressNext: onPressNext)
                         : SurveyQuestionContent(
                             title: question.text,
                             page: _selectedPage,
                             totalPage: surveyDetail.questions.length,
-                            onPressNext: () {
-                              FocusManager.instance.primaryFocus?.unfocus();
-                              if (_selectedPage ==
-                                  surveyDetail.questions.length) {
-                                widgetRef
-                                    .read(
-                                        surveyDetailViewModelProvider.notifier)
-                                    .submitSurvey(widget.surveyId);
-                              } else {
-                                goToNextPage();
-                              }
-                            },
+                            onPressNext: onPressNext,
                             child: _getQuestionContentChild(question),
                           ),
                   ]

--- a/lib/screens/detail/survey_intro_outro_content.dart
+++ b/lib/screens/detail/survey_intro_outro_content.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:survey_flutter/gen/assets.gen.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class SurveyIntroOutroContent extends StatefulWidget {
+  final String title;
+  final int page;
+  final int totalPage;
+  final VoidCallback onPressNext;
+
+  const SurveyIntroOutroContent({
+    required this.title,
+    required this.page,
+    required this.totalPage,
+    required this.onPressNext,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => SurveyIntroOutroContentState();
+}
+
+class SurveyIntroOutroContentState extends State<SurveyIntroOutroContent> {
+  TextTheme get _textTheme => Theme.of(context).textTheme;
+
+  AppLocalizations get _localizations => AppLocalizations.of(context)!;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _buildToolbar(false),
+        Align(
+          alignment: Alignment.topLeft,
+          child: Padding(
+            padding: const EdgeInsets.only(top: 40.5, left: 20, right: 20),
+            child: Text(
+              '${widget.page}/${widget.totalPage}',
+              style: _textTheme.labelSmall
+                  ?.copyWith(color: Colors.white.withOpacity(0.5)),
+            ),
+          ),
+        ),
+        Expanded(
+          child: SingleChildScrollView(
+            scrollDirection: Axis.vertical,
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: Padding(
+                padding: const EdgeInsets.only(top: 8, left: 20, right: 20),
+                child: Text(
+                  widget.title,
+                  style: _textTheme.titleLarge,
+                ),
+              ),
+            ),
+          ),
+        ),
+        Align(
+          alignment: Alignment.centerRight,
+          child: Padding(
+            padding: const EdgeInsets.only(bottom: 34, right: 20),
+            child: widget.page == widget.totalPage
+                ? SizedBox(
+                    width: 140,
+                    height: 56,
+                    child: ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.white,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(10.0),
+                        ),
+                      ),
+                      onPressed: widget.onPressNext,
+                      child: Text(
+                        _localizations.surveySubmit,
+                        style: _textTheme.labelMedium
+                            ?.copyWith(color: Colors.black),
+                      ),
+                    ),
+                  )
+                : SizedBox(
+                    width: 56,
+                    height: 56,
+                    child: FloatingActionButton(
+                      onPressed: widget.onPressNext,
+                      backgroundColor: Colors.white,
+                      child: Image.asset(Assets.images.icNavNext.path),
+                    ),
+                  ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildToolbar(bool showBack) {
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        if (showBack) ...[
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Padding(
+              padding: const EdgeInsets.only(
+                left: 14,
+                top: 52,
+              ),
+              child: IconButton(
+                  icon: Image.asset(Assets.images.icBack.path),
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                  }),
+            ),
+          ),
+        ] else ...[
+          Align(
+            alignment: Alignment.centerRight,
+            child: Padding(
+              padding: const EdgeInsets.only(
+                right: 16,
+                top: 52,
+              ),
+              child: IconButton(
+                  icon: Image.asset(Assets.images.icClose.path),
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                  }),
+            ),
+          )
+        ]
+      ],
+    );
+  }
+}


### PR DESCRIPTION
- Closes #101 

## What happened 👀

The title text for the intro and outro display type of survey questions is overflowing when the text is long. 

## Insight 📝

- Separate the content for the `intro` and `outro` questions
- Wrap the text inside the scroll so that if the text is too long, it will be scrollable to see more text

## Proof Of Work 📹

https://github.com/nimblehq/flutter-ic-kaung-thieu/assets/32578035/da00cea9-3baa-4058-883c-c3683f740d1c





