### PR TITLE
[#103] [Bug] Fix: Widget error when navigating to survey detail 

### DIFF
--- a/lib/screens/detail/survey_detail_screen.dart
+++ b/lib/screens/detail/survey_detail_screen.dart
@@ -253,7 +253,7 @@ class SurveyDetailScreenState extends ConsumerState<SurveyDetailScreen> {
                     );
               });
         default:
-          return const Expanded(child: SizedBox.shrink());
+          return const SizedBox();
       }
     });
   }


### PR DESCRIPTION
- Closes #103 

## What happened 👀


There is an implicit error when redirecting to the SurveyDetail
```
══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
The following assertion was thrown while applying parent data.:
Incorrect use of ParentDataWidget.
The ParentDataWidget Expanded(flex: 1) wants to apply ParentData of type FlexParentData to a
RenderObject, which has been set up to accept ParentData of incompatible type BoxParentData.
Usually, this means that the Expanded widget has the wrong ancestor RenderObjectWidget. Typically,
Expanded widgets are placed directly inside Flex widgets.
The offending Expanded is currently placed inside a Center widget.
The ownership chain for the RenderObject that received the incompatible parent data was:
  SizedBox.shrink ← Expanded ← Consumer ← Center ← Expanded ← Column ← SurveyQuestionContent ←
RepaintBoundary ← IndexedSemantics ← _SelectionKeepAlive ← ⋯
```

## Insight 📝

 `Expanded` widget was wrapped inside another `Expanded` widget in the `SurveyDetailScreen` and that was the error.

## Proof Of Work 📹


https://github.com/nimblehq/flutter-ic-kaung-thieu/assets/32578035/a8b8e9a2-5093-49a2-84b8-a575780ed87f


